### PR TITLE
feat: add Foxglove Bridge for remote Gazebo visualization

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,6 +15,7 @@ RUN curl -sSL https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/
 
 RUN apt-get update && apt-get install -y \
     gz-harmonic ros-jazzy-ros-gz ros-jazzy-actuator-msgs \
+    ros-jazzy-foxglove-bridge \
     libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
     gstreamer1.0-plugins-bad gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install-deps build start shell run reboot stop clean setup-workspace px4-sitl ardupilot-sitl dds-agent
+.PHONY: help install-deps build start shell run reboot stop clean setup-workspace px4-sitl ardupilot-sitl dds-agent foxglove-bridge
 
 # --in-pod 0: disable automatic pod creation, which conflicts with userns_mode: keep-id
 COMPOSE := podman-compose --in-pod 0
@@ -17,6 +17,7 @@ help:
 	@echo "  make setup-workspace - Clone and configure PX4 and ArduPilot"
 	@echo "  make px4-sitl        - Build and launch PX4 Gazebo SITL"
 	@echo "  make ardupilot-sitl  - Build and launch ArduPilot Gazebo SITL"
+	@echo "  make foxglove-bridge - Launch Foxglove Bridge (WebSocket on port 8765)"
 
 install-deps:
 	./scripts/install_host_deps.sh
@@ -74,4 +75,11 @@ ardupilot-sitl:
 		podman exec -it drone_sitl_dev /bin/bash -c "cd ardupilot/ArduCopter && sim_vehicle.py -v ArduCopter -f gazebo-iris --console"; \
 	else \
 		cd ardupilot/ArduCopter && sim_vehicle.py -v ArduCopter -f gazebo-iris --console; \
+	fi
+foxglove-bridge:
+	@if command -v podman >/dev/null 2>&1; then \
+		echo "Running via Podman exec..."; \
+		podman exec -it drone_sitl_dev /bin/bash -c "source /opt/ros/jazzy/setup.bash && ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765"; \
+	else \
+		ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765; \
 	fi


### PR DESCRIPTION
## Changes
- Add `ros-jazzy-foxglove-bridge` to the container image
- Add `make foxglove-bridge` target to launch the WebSocket bridge on port 8765
- Enables remote visualization and control of Gazebo SITL via Foxglove Studio
## Usage
1. Rebuild the container: `make build`
2. Start the bridge: `make foxglove-bridge`
3. Connect Foxglove Studio to `ws://<your-host-ip>:8765`